### PR TITLE
Move linear_extrude outside teeth loop

### DIFF
--- a/pd-gears.scad
+++ b/pd-gears.scad
@@ -117,9 +117,9 @@ module rack (
 ) {
 	a = mm_per_tooth / PI; //addendum
 	t = a*cos(pressure_angle)-mm_per_tooth/10;         //tooth side is tilted so top/bottom corners move this amount
+	linear_extrude(height = thickness, center = center, convexity = 10)
 		for (i = [0:number_of_teeth-1] )
 			translate([i*mm_per_tooth,0,0])
-				linear_extrude(height = thickness, center = center, convexity = 10)
 					polygon(
 						points=[
 							[-mm_per_tooth * 3/4,                 a-height],

--- a/pd-gears.scad
+++ b/pd-gears.scad
@@ -79,9 +79,9 @@ module gear (
 	t  = mm_per_tooth/2-backlash/2;                //tooth thickness at pitch circle
 	k  = -iang(b, p) - t/2/p/PI*180;             //angle to where involute meets base circle on each side of tooth
     difference() {
-        for (i = [0:(number_of_teeth-teeth_to_hide-1 > 0 ? 1 : -1):number_of_teeth-teeth_to_hide-1] )
-            rotate([0,0,i*360/number_of_teeth])
-                linear_extrude(height = thickness, center = center, convexity = 10, twist = twist)
+        linear_extrude(height = thickness, center = center, convexity = 10, twist = twist)
+            for (i = [0:(number_of_teeth-teeth_to_hide-1 > 0 ? 1 : -1):number_of_teeth-teeth_to_hide-1] )
+                rotate([0,0,i*360/number_of_teeth])
                     polygon(
                         points=[
                             [0, -hole_diameter/10],


### PR DESCRIPTION
Performing a linear_extrude on each tooth of a gear is both inefficient and prone to generating invalid geometry with internal surfaces. By moving the operation outside the loop the gear profile is assembled fully in 2D before extruding.

Before this change the geometry generated by the example has 236 CSG elements, and is very slow to manipulate in the preview window. After the change it has just 18 elements, and is correspondingly much faster.

I believe this change has no negative effects.